### PR TITLE
Update wc-gc-integration.gs

### DIFF
--- a/wc-gc-integration.gs
+++ b/wc-gc-integration.gs
@@ -138,6 +138,8 @@ function fetch_orders(sheet_name) {
         a = container.push(params[i]["status"]);
       
         a = container.push(params[i]["order_key"]);
+        
+           a = container.push(params[i]["CUSTOMFIELD"]);
 
 
         var doc = SpreadsheetApp.getActiveSpreadsheet();


### PR DESCRIPTION
Hi, I added a field to my page using a Custom Checkout fields plugin, i´m trying to pull the info in the custom field to the google sheets file, everything is working fine but instead of the value that the customer entered, it shows "undefined" in google sheets, please help, how do i get those custom fields importes into google sheest as well? just as it does with the name, value, products, etc.